### PR TITLE
Update ArchiveGenerator.rb

### DIFF
--- a/_plugins/ArchiveGenerator.rb
+++ b/_plugins/ArchiveGenerator.rb
@@ -22,12 +22,14 @@ module Jekyll
     safe true
     def generate(site)
       if site.layouts.key? 'archive'
-        site.posts.group_by{ |c| {"month" => c.date.month, "year" => c.date.year} }.each do |period, posts|
+# changed posts.group_by to posts.docs.group_by due to code's deprecation - unixfreaxjp
+        site.posts.docs.group_by{ |c| {"month" => c.date.month, "year" => c.date.year} }.each do |period, posts|
           archive_dir = File.join(period["year"].to_s(), "%02d" % period["month"].to_s())
           write_archive_index(site, archive_dir, period, posts)
         end
 
-        site.posts.group_by{ |c| {"year" => c.date.year} }.each do |period, posts|
+# changed posts.group_by to posts.docs.group_by due to code's deprecation - unixfreaxjp
+        site.posts.docs.group_by{ |c| {"year" => c.date.year} }.each do |period, posts|
           archive_dir = File.join(period["year"].to_s())
           write_archive_index(site, archive_dir, period, posts)
         end        


### PR DESCRIPTION
There's deprecation in codes (below) and it is fixed, pulling request.
```ruby
       Deprecation: posts.group_by should be changed toposts.docs.group_by.
```
The changes can be viewed [here](https://github.com/unixfreaxjp/ArchiveGenerator/blob/master/_plugins/ArchiveGenerator.rb), nothing fancy, but when time goes by the error will occur, please merge. Thank's.
